### PR TITLE
Fix callEffect assuming a non generator with array syntax

### DIFF
--- a/src/effect.ts
+++ b/src/effect.ts
@@ -49,12 +49,13 @@ function callEffect<Fn extends (...args: any[]) => any>(
   cancel: Promise<any>,
 ) {
   return speculation((resolve, reject, onCancel) => {
+    let gen: any;
     if (Array.isArray(fn)) {
       const [obj, fnName, ...fargs] = fn;
-      return resolve(obj[fnName](...fargs));
+      gen = obj[fnName](...fargs);
+    } else {
+      gen = fn.call(this, ...args);
     }
-
-    const gen = fn.call(this, ...args);
 
     if (!gen || typeof gen.next !== 'function') {
       return resolve(gen);

--- a/test/context.ts
+++ b/test/context.ts
@@ -1,15 +1,41 @@
-import { task } from '../src/index';
+import { task, call } from '../src/index';
 import * as test from 'tape';
-
-const ctx = {
-  some: 'thing',
-};
 
 test('co.call(this) should pass the context', (t) => {
   t.plan(1);
 
+  const ctx = {
+    some: 'thing',
+  };
+
   // @ts-ignore
   task.call(ctx, function*(this: any) {
     t.ok(ctx == this);
+  });
+});
+
+test('call([]) should pass context to a generator', (t) => {
+  t.plan(3);
+
+  let ctx: GenClass;
+
+  class GenClass {
+    two() {
+      t.ok(ctx == this);
+      return Promise.resolve(2);
+    }
+
+    * one() {
+      t.ok(ctx == this);
+      return yield call<any>([this, 'two']);
+    }
+  }
+
+  ctx = new GenClass;
+
+  // @ts-ignore
+  task.call(ctx, function*(this: any) {
+    const result = yield call([ctx, 'one']);
+    t.ok(result === 2);
   });
 });


### PR DESCRIPTION
Closes #12

Changes `callEffect` to not immediately resolve when it detects that it was passed the array syntax. 

When passed array syntax, `callEffect` always assumed you wanted to call an async function, when you could want to call a generator function. `callEffect` will now test for a generator no matter what the argument call style. If it finds a generator, it will run it, otherwise it will resolve the result of the function call. 

Added a test to verify. 